### PR TITLE
bump version in package.json to v0.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ng-browser-info",
   "description": "ngBrowserInfo is an AngularJS service that gives you a collection of methods for knowing more about your client browser.",
   "keywords": ["client", "info", "useragent", "navigator", "angularjs", "angular", "os", "browser", "screen", "cookies"],
-  "version": "0.1.4",
+  "version": "0.1.6",
   "license": "Apache 2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Package v0.1.5 had no version bump resulting in some errors/warnings when package was installed:

> `warning Pattern ["ng-browser-info@transferwise/ng-browser-info"] is trying to unpack in the same destination "/home/ubuntu/.cache/yarn/v1/npm-ng-browser-info-0.1.4-ecc4b79071a31c33ce15c025bbb6dda58080875a" as pattern ["ng-browser-info@git+ssh://git@github.com/transferwise/ng-browser-info.git#0.1.5"]. This could result in a non deterministic behavior, skipping.`